### PR TITLE
add the PythonRobotics link

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ Open-source library to create robot's behaviors in form of Behavior Trees runnin
 [**g2core**](https://github.com/synthetos/g2)
 Open-source motion control software for CNC and Robotics, designed to run on Arduino Due class microcontrollers.
 
+[**PythonRobotics**](https://github.com/AtsushiSakai/PythonRobotics) 
+Open-source python code collection of various robotics algorithms with visualizations.
+
 ### Papers ###
 * [Optimization Based Controller Design and Implementation for the
 Atlas Robot in the DARPA Robotics Challenge Finals](https://www.cs.cmu.edu/~cga/drc/ICHR15_0025_MS.pdf)


### PR DESCRIPTION
I propose to add the link of PythonRobotics project : [PythonRobotics](https://github.com/AtsushiSakai/PythonRobotics) 