### PR TITLE
Add Pan-African Robotics Competition to the list of competition category

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Atlas Robot in the DARPA Robotics Challenge Finals](https://www.cs.cmu.edu/~cga/
 * [Intelligent Ground Vehicle Competition](http://www.igvc.org/)
 * [Robotex](https://robotex.ee/en/) The biggest robotics festival in Europe
 * [First Lego League](https://www.firstlegoleague.org/)
+* [Pan-African Robotics Competition - Engineers League](https://www.parcrobotics.org/)
 
 ### Companies ###
 * [Boston Dynamics](http://www.bostondynamics.com/) robotics R&D company, creator of the state of the art [Atlas](https://www.youtube.com/watch?v=rVlhMGQgDkY) and [Spot](https://www.youtube.com/watch?v=M8YjvHYbZ9w) robots


### PR DESCRIPTION
Pan-African Robotics Competition (PARC) is an annual robotics competition for Africans. The Engineers League category of this competition is the most advanced where participants use the Robot Operating System (ROS) and a simulator such as Gazebo to perform robotic tasks geared towards solving a problem related to the African landscape.

Information on the PARC 2024 Engineers League category, which was based on autonomous farming, can be found at [Pan African Robotics Competition 2024](https://parc-robotics.github.io/documentation-2024/introduction/)