### PR TITLE
fix: Remove Robotics Specialization by GRASP Lab from Courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ This is a list of various books, courses and other resources for robotics. It's 
 * [Robot Mechanics and Control, Part I](https://www.edx.org/course/robot-mechanics-control-part-i-snux-snu446-345-1x) **edX**
 * [Robot Mechanics and Control, Part II](https://www.edx.org/course/robot-mechanics-control-part-ii-snux-snu446-345-2x) **edX**
 * [Autonomous Navigation for Flying Robots](https://www.edx.org/course/autonomous-navigation-flying-robots-tumx-autonavx-0) **edX**
-* [Robotics Specialization by GRASP Lab](https://www.coursera.org/specializations/robotics) **Coursera** :dollar:
 * [Control of Mobile Robots](https://www.coursera.org/course/conrob) **Coursera**
 * [QUT Robot Academy](https://robotacademy.net.au/) **QUT**
 * [Robotic vision](https://www.qut.edu.au/study/short-courses-and-professional-development/short-courses/robotic-vision) **QUT**


### PR DESCRIPTION
Removed the Robotics Specialization by GRASP Lab from the Courses list because the URL (https://www.coursera.org/specializations/robotics) shows a 404 error with a "We were not able to find the page you're looking for" message.
![](https://github.com/user-attachments/assets/6597d7a8-be56-4f7d-9eda-61b5d48f1a72)