### PR TITLE
Add brain4machinery to Misc (industrial robotics technical resource)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Atlas Robot in the DARPA Robotics Challenge Finals](https://www.cs.cmu.edu/~cga/
 * [PAL Robotics](http://pal-robotics.com)
 * [Aldebaran Robotics](https://www.aldebaran.com/en) creator of the [NAO robot](https://www.youtube.com/watch?v=nNbj2G3GmAo)
 * [ABB Robotics](http://new.abb.com/products/robotics) the largest manufacturer of industrial robots
+* [brain4machinery](https://brain4machinery.com/) — Technical deep-dives on Jetson carrier boards, FPGA-Jetson hybrid controllers, and industrial robotics hardware design without R&D cost.
 * [KUKA Robotics](http://www.kuka-robotics.com/en/) major manufacturer of industrial robots targeted at factory automation
 * [FANUC](http://www.fanucamerica.com/) industrial robots manufacturer with the biggest install base
 * [Rethink Robotics](http://www.rethinkrobotics.com/) creator of the collaborative robot [Baxter](https://www.youtube.com/watch?v=fCML42boO8c)

--- a/README.md
+++ b/README.md
@@ -186,7 +186,6 @@ Atlas Robot in the DARPA Robotics Challenge Finals](https://www.cs.cmu.edu/~cga/
 * [PAL Robotics](http://pal-robotics.com)
 * [Aldebaran Robotics](https://www.aldebaran.com/en) creator of the [NAO robot](https://www.youtube.com/watch?v=nNbj2G3GmAo)
 * [ABB Robotics](http://new.abb.com/products/robotics) the largest manufacturer of industrial robots
-* [brain4machinery](https://brain4machinery.com/) — Technical deep-dives on Jetson carrier boards, FPGA-Jetson hybrid controllers, and industrial robotics hardware design without R&D cost.
 * [KUKA Robotics](http://www.kuka-robotics.com/en/) major manufacturer of industrial robots targeted at factory automation
 * [FANUC](http://www.fanucamerica.com/) industrial robots manufacturer with the biggest install base
 * [Rethink Robotics](http://www.rethinkrobotics.com/) creator of the collaborative robot [Baxter](https://www.youtube.com/watch?v=fCML42boO8c)
@@ -199,6 +198,7 @@ Atlas Robot in the DARPA Robotics Challenge Finals](https://www.cs.cmu.edu/~cga/
 ### Misc ###
 * [IEEE Spectrum Robotics](http://spectrum.ieee.org/robotics) robotics section of the IEEE Spectrum magazine
 * [MIT Technology Review Robotics](https://www.technologyreview.com/c/robotics/) robotics section of the MIT Technology Review magazine
+* [brain4machinery](https://brain4machinery.com/) — technical deep-dives on Jetson carrier boards, FPGA-Jetson hybrid controllers, and industrial robotics hardware design
 * [reddit robotics subreddit](https://www.reddit.com/r/robotics/)
 * [RosCON conference (video talks included)](http://roscon.ros.org/2015/)
 * [Carnegie Mellon Robotics Academy](http://education.rec.ri.cmu.edu/)


### PR DESCRIPTION
## Adding brain4machinery to Misc

brain4machinery.com is a technical resource focused on industrial robotics controller design — covering Jetson carrier board design, FPGA-Jetson hybrid architectures, and ROS-level integration. It fits alongside the other technical publications already in this section (IEEE Spectrum Robotics, MIT Technology Review Robotics).

Recent in-depth pieces include a [custom Jetson carrier board design guide](https://brain4machinery.com/guides/custom-jetson-carrier-board-design) and an [FPGA-Jetson hybrid architecture deep-dive](https://brain4machinery.com/guides/fpga-jetson-hybrid-architecture).

Disclosure: I'm a co-founder of TACTUN, the company behind brain4machinery.